### PR TITLE
Add support for Windows home directory.

### DIFF
--- a/src/mmry/cache.py
+++ b/src/mmry/cache.py
@@ -4,6 +4,7 @@ __all__ = [
 
 import os
 import hashlib
+import platform
 from functools import lru_cache
 
 
@@ -17,6 +18,8 @@ class Cache:
         if (root := os.getenv('MMRY_CACHE_ROOT')):
             return root
         # otherwise, use the canonical location in $HOME
+        if platform.system() == "Windows":
+            return os.path.join(os.getenv('USERPROFILE'), '.cache', 'mmry')
         return os.path.join(os.getenv('HOME'), '.cache', 'mmry')
 
     @staticmethod


### PR DESCRIPTION
Windows by default stores its "HOME" directory in `USERPROFILE` env variable rather than in `HOME`.

Doing `self.default_root()` when initializing a Cache object on Windows, throws the following error:
```
File ~\AppData\Local\Programs\Python\Python312\Lib\site-packages\mmry\cache.py:20, in Cache.default_root()
     18     return root
     19 # otherwise, use the canonical location in $HOME
---> 20 return os.path.join(os.getenv('HOME'), '.cache', 'mmry')

File <frozen ntpath>:108, in join(path, *paths)

TypeError: expected str, bytes or os.PathLike object, not NoneType
```
because on Windows `os.getenv("HOME")` returns `NoneType` object and `os.path.join` then throws an error.

Added simple conditional to check if we are on Windows, and read from USERPROFILE if we are.

Woot woot! 🎉
 